### PR TITLE
NH-17397-SolarWinds-APM-Release (12.0.0)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -61,8 +61,10 @@ Those are available in the Docker Dev Container.
 ## Docker Dev Container
 
 1. Start the Docker daemon (on a Mac that would be simplest using Docker desktop).
-2. Create a `.env` file and set two sets of keys for the backend:
-- `SW_APM_SERVICE_KEY={a valid service key}`, `SW_APM_COLLECTOR={a url of the collector}` and `SW_TEST_PROD_SERVICE_KEY={a valid **production** service key}`.
+2. Create a `.env` file and set keys for the backend:
+- `SW_TEST_PROD_SERVICE_KEY={a valid **production** service key}`
+- `SW_APM_SERVICE_KEY={a valid service key to any of dev/staging/production}`
+- `SW_APM_COLLECTOR={optional url of the collector at dev/staging}`
 3. Run `npm run dev`. This will create a docker container, set it up, and open a shell. Docker container will have all required build tools as well as nano installed, and access to GitHub SSH keys as configured. Repo code is **mounted** to the container.
 4. To open another shell in same container use: `docker exec -it dev-bindings /bin/bash`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "solarwinds-apm-bindings",
-      "version": "12.0.0-prerelease.4",
+      "version": "12.0.0-prerelease.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solarwinds-apm-bindings",
-  "version": "12.0.0-prerelease.6",
+  "version": "12.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solarwinds-apm-bindings",
-      "version": "12.0.0-prerelease.6",
+      "version": "12.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "!darwin",
     "!win32"
   ],
-  "version": "12.0.0-prerelease.6",
+  "version": "12.0.0",
   "description": "Bindings for solarwinds-apm with pre-built support",
   "contributors": [
     "Stephen Belanger <admin@stephenbelanger.com>",


### PR DESCRIPTION
## Overview
This is a pull request for a **release** version bump (major).

## Release Notes

Breaking changes
- Transforms the [bindings for the AppOptics Agent](https://github.com/appoptics/appoptics-bindings-node) into the bindings for the SolarWinds APM Agent.

- Enabled support for liboboe `10.5.2` in mode 1 (W3C).
  - init options include mode and options updated to version `13`.
  - `Event::makeFromBuffer` accepts either `xtrace` or `traceparent` input and acts accordingly.
  - `getTraceSettings` accepts either `xtrace` or `traceparent` input and acts accordingly.
  - `getTraceSettings` accepts a `tracestate` as input and passes to liboboe tracing decision method.
  - javascript `Event.makeFromString` (wrapper to `Event::makeFromBuffer`) accepts either `xtrace` or `traceparent` input.
  - Event.toString functionality can generate various formatted outputs in both mode 0 and mode 1.

- Tightened regex validation of `xtrace` and `traceparent`.
- Updated logic used to decide if a trace has metadata due to api changes introduced in liboboe `10.4.0` and above.
- Remove Disabled Notifier Dead Code.
- Remove SQL Sanitization (Agent responsibility).
- EOL Node `10` and `12`.
- Gracefully Disable Lambda Functionality.

## Note
Merging this pull request does not trigger the release. The release is triggered manually by starting of a [Release GitHub workflow](https://github.com/appoptics/appoptics-bindings-node/actions/workflows/release.yml). This should be done after all other workflows pass.